### PR TITLE
Resolves 12. As a user, I want to view a list of my shopping list items in order of how soon I am likely to need to buy each of them again so that it’s clear what I need to buy soon.

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -25,11 +25,11 @@
   background-color: green;
 }
 
-.kindaSoon {
+.kinda-soon {
   background-color: yellow;
 }
 
-.notSoon {
+.not-soon {
   background-color: red;
 }
 

--- a/src/App.css
+++ b/src/App.css
@@ -20,3 +20,19 @@
 .App-link {
   color: #09d3ac;
 }
+
+.soon {
+  background-color: green;
+}
+
+.kindaSoon {
+  background-color: yellow;
+}
+
+.notSoon {
+  background-color: red;
+}
+
+.inactive {
+  background-color: lightgrey;
+}

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -1,17 +1,17 @@
-import React, { useState } from 'react';
-import getToken from '../lib/tokens.js';
-import { useHistory } from 'react-router-dom';
-import { db } from '../lib/firebase';
+import React, { useState } from "react";
+import getToken from "../lib/tokens.js";
+import { useHistory } from "react-router-dom";
+import { db } from "../lib/firebase";
 
 const Home = (props) => {
-  const [token, setToken] = useState('');
+  const [token, setToken] = useState("");
   const history = useHistory();
 
   const generateToken = () => {
     const token = getToken();
-    localStorage.setItem('token', token);
+    localStorage.setItem("token", token);
     props.setAuth(token);
-    history.push('/List');
+    history.push("/List");
   };
 
   const onTokenInputChange = (e) => {
@@ -25,18 +25,18 @@ const Home = (props) => {
       .get()
       .then((querySnapshot) => {
         if (querySnapshot.empty) {
-          alert('uh oh! list does not exist');
+          alert("uh oh! list does not exist");
         } else {
-          localStorage.setItem('token', token);
+          localStorage.setItem("token", token);
           props.setAuth(token);
-          history.push('/List');
+          history.push("/List");
         }
       })
       .catch((error) => {
         alert(error);
       });
 
-    setToken('');
+    setToken("");
   };
 
   return (

--- a/src/components/ShoppingList/PopulatedList.js
+++ b/src/components/ShoppingList/PopulatedList.js
@@ -32,21 +32,20 @@ const PopulatedList = () => {
       // Map over new array and calculate days until next purchase for each item
       // Set as new property on object (only saved in our app - not in db)
       list.map((doc) => {
-        doc.daysUntilPurchase = calculateDaysTilNextPurchase(doc);
+        doc.purchaseCountdown = calculateDaysTilNextPurchase(doc);
       });
 
       // Sort by days until next purchase
-      // The if/else ensures that 'null' (inactive) items will always be at bottom - thanks stackoverflow
+      // The if/else ensures that 'null' (inactive) items will always be at bottom
       list.sort(function (a, b) {
-        if (a.daysUntilPurchase === null) {
+        if (a.purchaseCountdown === null) {
           return 1;
-        } else if (b.daysUntilPurchase === null) {
+        } else if (b.purchaseCountdown === null) {
           return -1;
         }
-        return a.daysUntilPurchase < b.daysUntilPurchase ? -1 : 1;
+        return a.purchaseCountdown < b.purchaseCountdown ? -1 : 1;
       });
 
-      // Run filter on our new list and set state using this list
       let filtered = list.filter((doc) => {
         return doc.itemName.toLowerCase().includes(filterValue.toLowerCase());
       });
@@ -112,16 +111,16 @@ const PopulatedList = () => {
         (24 * 60 * 60 * 1000),
     );
     if (daysElapsed > 2 * itemObj.daysToPurchase) return null;
-    const daysUntilPurchase = itemObj.daysToPurchase - daysElapsed;
-    return daysUntilPurchase;
+    const purchaseCountdown = itemObj.daysToPurchase - daysElapsed;
+    return purchaseCountdown;
   }
 
   function getClassName(itemObj) {
-    if (itemObj.daysUntilPurchase === null) {
+    if (itemObj.purchaseCountdown === null) {
       return "inactive";
-    } else if (itemObj.daysUntilPurchase < 7) {
+    } else if (itemObj.purchaseCountdown < 7) {
       return "soon";
-    } else if (itemObj.daysUntilPurchase < 30) {
+    } else if (itemObj.purchaseCountdown < 30) {
       return "kinda-soon";
     } else {
       return "not-soon";
@@ -148,8 +147,6 @@ const PopulatedList = () => {
       <div>
         {listData && (
           <ul>
-            {/* All of these methods have been updated so we're just iterating over
-            our simple array rather than .doc.data() etc */}
             {filteredList.map((groceryItem) => (
               <Fragment key={groceryItem.id}>
                 <input

--- a/src/components/ShoppingList/PopulatedList.js
+++ b/src/components/ShoppingList/PopulatedList.js
@@ -2,6 +2,7 @@ import React, { Fragment, useState, useEffect } from "react";
 import { useCollection } from "react-firebase-hooks/firestore";
 import { db } from "../../lib/firebase";
 import calculateEstimate from "../../lib/estimates";
+import swal from "@sweetalert/with-react";
 
 const PopulatedList = () => {
   const [listData] = useCollection(
@@ -62,9 +63,22 @@ const PopulatedList = () => {
     setFilterValue("");
   };
 
-  // const deleteItemHandler = (id) => {
-  //   db.collection(localStorage.getItem("token")).doc(id).delete();
-  // };
+  const deleteItemHandler = (id) => {
+    swal({
+      title: "Are you sure?",
+      text: "Once deleted, you cannot revert back.",
+      icon: "warning",
+      buttons: true,
+      dangerMode: true,
+    }).then((willDelete) => {
+      if (willDelete) {
+        db.collection(localStorage.getItem("token")).doc(id).delete();
+        swal("Item deleted!", {
+          icon: "success",
+        });
+      }
+    });
+  };
 
   const onPurchaseChange = (e, itemData) => {
     if (e.target.checked) {
@@ -127,6 +141,14 @@ const PopulatedList = () => {
     }
   }
 
+  const itemCard = {
+    margin: "10px",
+    padding: "10px",
+    border: "1px solid black",
+    display: "flex",
+    flexDirection: "column",
+  };
+
   return (
     <div className="shopping-list">
       <h1>Shopping List</h1>
@@ -151,27 +173,28 @@ const PopulatedList = () => {
           <ul>
             {filteredList.map((groceryItem) => (
               <Fragment key={groceryItem.id}>
-                <p
-                  // onClick={() => deleteItemHandler(groceryItem.id)}
-                  className={getClassName(groceryItem)}
-                  aria-label="Item name and days to purchase"
-                >
-                  {groceryItem.itemName} - {groceryItem.daysToPurchase} days
-                </p>
-                <label>
-                  Purchased?{" "}
-                  <input
-                    aria-label="Purchased?"
-                    type="checkbox"
-                    id={groceryItem.itemName}
-                    name={groceryItem.itemName}
-                    value={groceryItem.id}
-                    onChange={(e) => onPurchaseChange(e, groceryItem)}
-                    checked={hasItemBeenPurchased(
-                      groceryItem.lastPurchasedDate,
-                    )}
-                  />
-                </label>
+                <div style={itemCard} className={getClassName(groceryItem)}>
+                  <text aria-label="Item name and days to purchase">
+                    {groceryItem.itemName} - {groceryItem.daysToPurchase} days
+                  </text>
+                  <label>
+                    Purchased?{" "}
+                    <input
+                      aria-label="Purchased?"
+                      type="checkbox"
+                      id={groceryItem.itemName}
+                      name={groceryItem.itemName}
+                      value={groceryItem.id}
+                      onChange={(e) => onPurchaseChange(e, groceryItem)}
+                      checked={hasItemBeenPurchased(
+                        groceryItem.lastPurchasedDate,
+                      )}
+                    />{" "}
+                  </label>
+                  <button onClick={() => deleteItemHandler(groceryItem.id)}>
+                    Delete
+                  </button>
+                </div>
               </Fragment>
             ))}
           </ul>

--- a/src/components/ShoppingList/PopulatedList.js
+++ b/src/components/ShoppingList/PopulatedList.js
@@ -63,9 +63,9 @@ const PopulatedList = () => {
     setFilterValue("");
   };
 
-  const deleteItemHandler = (id) => {
-    db.collection(localStorage.getItem("token")).doc(id).delete();
-  };
+  // const deleteItemHandler = (id) => {
+  //   db.collection(localStorage.getItem("token")).doc(id).delete();
+  // };
 
   const onPurchaseChange = (e, itemData) => {
     if (e.target.checked) {
@@ -131,15 +131,17 @@ const PopulatedList = () => {
   return (
     <div className="shopping-list">
       <h1>Shopping List</h1>
-      <input
-        aria-label="Filter Items"
-        id="itemFilter"
-        name="itemFilter"
-        type="text"
-        placeholder="Filter items..."
-        value={filterValue}
-        onChange={onFilterChange}
-      />
+      <label>
+        Filter items:{" "}
+        <input
+          aria-label="Filter Items"
+          id="itemFilter"
+          name="itemFilter"
+          type="text"
+          value={filterValue}
+          onChange={onFilterChange}
+        />
+      </label>
       {filterValue !== "" && (
         <button aria-label="Clear filter" onClick={resetFilter}>
           X
@@ -152,18 +154,24 @@ const PopulatedList = () => {
             our simple array rather than .doc.data() etc */}
             {filteredList.map((groceryItem) => (
               <Fragment key={groceryItem.id}>
-                <input
-                  type="checkbox"
-                  id={groceryItem.itemName}
-                  name={groceryItem.itemName}
-                  value={groceryItem.id}
-                  onChange={(e) => onPurchaseChange(e, groceryItem)}
-                  checked={hasItemBeenPurchased(groceryItem.lastPurchasedDate)}
-                ></input>
+                <label>
+                  Purchased?{" "}
+                  <input
+                    aria-label="Purchased?"
+                    type="checkbox"
+                    id={groceryItem.itemName}
+                    name={groceryItem.itemName}
+                    value={groceryItem.id}
+                    onChange={(e) => onPurchaseChange(e, groceryItem)}
+                    checked={hasItemBeenPurchased(
+                      groceryItem.lastPurchasedDate,
+                    )}
+                  />
+                </label>
                 <li
-                  onClick={() => deleteItemHandler(groceryItem.id)}
+                  // onClick={() => deleteItemHandler(groceryItem.id)}
                   className={getClassName(groceryItem)}
-                  aria-labelledby="{groceryItem.itemName} should be bought on {groceryItem.daysToPurchase}"
+                  aria-label="Grocery Item to be purchased."
                 >
                   {groceryItem.itemName} - {groceryItem.daysToPurchase}
                 </li>

--- a/src/components/ShoppingList/PopulatedList.js
+++ b/src/components/ShoppingList/PopulatedList.js
@@ -151,6 +151,13 @@ const PopulatedList = () => {
           <ul>
             {filteredList.map((groceryItem) => (
               <Fragment key={groceryItem.id}>
+                <p
+                  // onClick={() => deleteItemHandler(groceryItem.id)}
+                  className={getClassName(groceryItem)}
+                  aria-label="Item name and days to purchase"
+                >
+                  {groceryItem.itemName} - {groceryItem.daysToPurchase} days
+                </p>
                 <label>
                   Purchased?{" "}
                   <input
@@ -165,13 +172,6 @@ const PopulatedList = () => {
                     )}
                   />
                 </label>
-                <li
-                  // onClick={() => deleteItemHandler(groceryItem.id)}
-                  className={getClassName(groceryItem)}
-                  aria-label="Grocery Item to be purchased."
-                >
-                  {groceryItem.itemName} - {groceryItem.daysToPurchase}
-                </li>
               </Fragment>
             ))}
           </ul>

--- a/src/components/ShoppingList/PopulatedList.js
+++ b/src/components/ShoppingList/PopulatedList.js
@@ -9,7 +9,7 @@ const PopulatedList = () => {
 
       // Sort in alphabetical order from DB
       .collection(localStorage.getItem("token"))
-      .orderBy("itemName"),
+      .orderBy("itemName", "desc"),
     {
       snapshotListenOptions: { includeMetadataChanges: true },
     },
@@ -163,8 +163,9 @@ const PopulatedList = () => {
                 <li
                   onClick={() => deleteItemHandler(groceryItem.id)}
                   className={getClassName(groceryItem)}
+                  aria-labelledby="{groceryItem.itemName} should be bought on {groceryItem.daysToPurchase}"
                 >
-                  {groceryItem.itemName}
+                  {groceryItem.itemName} - {groceryItem.daysToPurchase}
                 </li>
               </Fragment>
             ))}

--- a/src/components/ShoppingList/PopulatedList.js
+++ b/src/components/ShoppingList/PopulatedList.js
@@ -5,7 +5,10 @@ import calculateEstimate from "../../lib/estimates";
 
 const PopulatedList = () => {
   const [listData] = useCollection(
-    db.collection(localStorage.getItem("token")),
+    db
+      .collection(localStorage.getItem("token"))
+      .orderBy("daysToPurchase")
+      .orderBy("itemName"),
     {
       snapshotListenOptions: { includeMetadataChanges: true },
     },
@@ -77,6 +80,19 @@ const PopulatedList = () => {
     return isMoreThanADay;
   };
 
+  // function getClassName(lastPurchasedDate, daysToPurchase) {
+  //   const daysElapsed = Math.floor(
+  //     (Date.now() - lastPurchasedDate.toMillis()) / (24 * 60 * 60 * 1000),
+  //   );
+  //   const daysUntilPurchase = daysToPurchase - daysElapsed;
+
+  //   if (daysElapsed > 2 * daysToPurchase || !lastPurchasedDate)
+  //     return "inactive";
+  //   if (daysUntilPurchase < 7) return "soon";
+  //   if (daysUntilPurchase >= 7 && daysUntilPurchase <= 30) return "kinda-soon";
+  //   if (daysToPurchase > 30) return "not-soon";
+  // }
+
   return (
     <div className="shopping-list">
       <h1>Shopping List</h1>
@@ -98,7 +114,13 @@ const PopulatedList = () => {
         {listData && (
           <ul>
             {filteredList.map((groceryItem) => (
-              <Fragment key={groceryItem.id}>
+              <Fragment
+                key={groceryItem.id}
+                // className={getClassName(
+                //   groceryItem.data().lastPurchasedDate,
+                //   groceryItem.data().daysToPurchase,
+                // )}
+              >
                 <input
                   type="checkbox"
                   id={groceryItem.data().itemName}


### PR DESCRIPTION
## Description

This PR will organize our list by time to next purchase and then alphabetically by item within each purchase. Additonally it will color code red, yellow, green, or grey depending on the item's estimated purchase range per the desired AC numbers. In this PR we had to learn a lot about queries with firestore, specifically compound queries with more than one index. In the end however we decided to create a client side function with the built in sort method to evaluate purchase estimates and compare to the list array containing our database. We chose this route so that we could focus on the color coding locally and in realtime while reducing the I/O with the Firestore database. This allowed for an easy color coding method that will update each time the user looks at the list. We may want to refactor this into a switch case should our styling get more complex or our color status get more specific,

Additionally we added some basic accessibility with aria-labels and also made a few changes to other UI elements and labels to be more accessible per MDN docs here: https://developer.mozilla.org/en-US/docs/Web/Accessibility/Understanding_WCAG
  
<!-- What does this code change? Why did I choose this approach? Did I learn anything worth sharing? Reminder: This will be a publicly facing representation of your work (READ: help you land that sweet dev gig). -->

## Related Issue

closes #12 

## Acceptance Criteria

* Items in the list are shown as visually distinct (e.g., with a different background color on the list item) according to how soon the item is expected to be bought again: Soon, Kind of soon, Not soon, Inactive
* Items should be sorted by the estimated number of days until next purchase
* Items with the same number of estimated days until next purchase should be sorted alphabetically
* Items in the different states should be described distinctly when read by a screen reader


## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|    | :bug: Bug fix              |
|  ✓  | :sparkles: New feature     |
|  ✓  | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Updates

### Before

![filter list](https://i.gyazo.com/793850ebf5632ca38b41935bf128fc09.gif)

### After

![after-shot](https://i.ibb.co/xYMM1Sy/Screenshot-2021-02-12-143130.png)

## Testing Steps / QA Criteria

* pull the latest commit of this branch into your local IDE
* run the code on a local server in the browser
* try adding a few new items to your list testing for different estimates and alphabetical order per color
* on a mac press 'cmd + F5' to activate a screen reader, for windows download NVDA screen reader here: https://www.nvaccess.org/download/ and follow instructions - once the screen reader is active mouse or tab around to hear labeled elements
* use chrome or firefox dev tools to inspect accessibility properties and check for suggestions

