### PR TITLE
Resolves 22. As a user, I want to view my token and log out without navigating to my shopping list

### DIFF
--- a/src/components/Navbar/Navbar.js
+++ b/src/components/Navbar/Navbar.js
@@ -58,22 +58,30 @@ export default function Navbar(props) {
       ) : (
         <header className="navContainer">
           <nav className="navStyle">
-            <Link className="homeLink" to="/">
-              <MCB />
-              <h1>MCB</h1>
-            </Link>
-            <Link className="navLink" to="/List">
-              <ListView />
-            </Link>
-            <Link className="navLink" to="/AddItem">
-              <AddItem />
-            </Link>
-            <Link className="navLink" onClick={clearTokenHandler}>
-              <ChangeList />
-            </Link>
-            <Link className="navLink" onClick={shareTokenHandler}>
-              <ShareList />
-            </Link>
+            <ul>
+              <li className="homeLi">
+                <Link className="homeLink" to="/">
+                  <MCB />
+                  <h1>MCB</h1>
+                </Link>
+              </li>
+              <li className="navLi"> 
+                <Link to="/List">
+                  <ListView />
+                </Link>
+              </li>
+              <li className="navLi">
+                <Link to="/AddItem">
+                  <AddItem />
+                </Link>
+              </li>
+              <li className="navLi" onClick={clearTokenHandler}>
+                  <ChangeList />
+              </li>
+              <li className="navLi" onClick={shareTokenHandler}>
+                  <ShareList />
+              </li>
+            </ul>
           </nav>
         </header>
       )}

--- a/src/components/Navbar/Navbar.js
+++ b/src/components/Navbar/Navbar.js
@@ -18,14 +18,14 @@ export default function Navbar(props) {
     swal({
       title: token,
       text:
-        "Write down this three-word token phrase to share access with friends or reaccess this list yourself",
+        "Write down this code to share this list with friends or re-access yourself!",
       dangerMode: true,
     });
   };
 
   const clearTokenHandler = () => {
     swal({
-      title: "Do you want to eject this list and access another?",
+      title: "Do you want to eject and access another list?",
       icon: "warning",
       buttons: true,
       dangerMode: true,

--- a/src/components/Navbar/Navbar.scss
+++ b/src/components/Navbar/Navbar.scss
@@ -1,12 +1,18 @@
-.navLink {
-  margin-left: 1em;
+.homeLi {
+  float: left;
+}
+
+.navLi {
+  float: left;
+  margin: 2.25em .25em 0em;
+  cursor: pointer;
 }
 
 .homeLink {
   display: flex;
   align-items: center;
   color: black;
-  margin-right: 2.5em;
+  margin-right: 2em;
 }
 
 .navContainer {
@@ -16,6 +22,7 @@
 }
 
 .navStyle {
+  list-style-type: none;
   display: flex;
   align-items: center;
   align-content: space-between;

--- a/src/styles/swal.scss
+++ b/src/styles/swal.scss
@@ -14,6 +14,10 @@
     background-color: $orange;
     @include input;
     width: auto;
+
+    @include maxScreen($tablet) {
+        width: auto;
+    }
 }
   
 .swal-button--cancel {
@@ -22,4 +26,8 @@
     background-color: $not-soon;
     @include input;
     width: auto;
+
+    @include maxScreen($tablet) {
+        width: auto;
+    }
 }

--- a/src/styles/swal.scss
+++ b/src/styles/swal.scss
@@ -10,7 +10,6 @@
 }
 
 .swal-button--confirm {
-<<<<<<< HEAD
     font-size: 15px;
     background-color: $orange;
     @include input;
@@ -19,16 +18,9 @@
     @include maxScreen($tablet) {
         width: auto;
     }
-=======
-  font-size: 15px;
-  background-color: $orange;
-  @include input;
-  width: auto;
->>>>>>> issue-13-development
 }
 
 .swal-button--cancel {
-<<<<<<< HEAD
     font-size: 15px;
     color: $black;
     background-color: $not-soon;
@@ -39,11 +31,3 @@
         width: auto;
     }
 }
-=======
-  font-size: 15px;
-  color: $black;
-  background-color: $not-soon;
-  @include input;
-  width: auto;
-}
->>>>>>> issue-13-development


### PR DESCRIPTION
## Description

This code changes the navigation bar, specifically the use of `Link` to avoid the issue we had with the user navigating to shopping list when they clicked on "share token" or "log out". 

To do this, I updated `Navbar.js` to include a `ul` with each item on the navbar as an `li`. I then removed the `Link` for the "share token" and "log out" icons. I also updated our `Navbar.scss` to adjust the `li` behavior and reflect the design that we had originally. 

Additionally, I noticed that the buttons for the sweet alerts were unnecessarily responsive when viewing on a tablet or phone. Therefore I updated `swal.scss` to not change like the other buttons.

## Related Issue

closes #47 

## Acceptance Criteria

clicking on either "share token" or "log out" the user will remain on the same page

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|  ✓  | :bug: Bug fix              |
|    | :sparkles: New feature     |
|  ✓  | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Updates

### Before

[![Image from Gyazo](https://i.gyazo.com/6be630ccd43c0215fc8f0e723301f358.gif)](https://gyazo.com/6be630ccd43c0215fc8f0e723301f358)

### After

[![Image from Gyazo](https://i.gyazo.com/5fefa76448e166acfc80a9413dea8000.gif)](https://gyazo.com/5fefa76448e166acfc80a9413dea8000)

## Testing Steps / QA Criteria

1. change to branch `wl-token-logout-navigation`
2. click on `share token` and `log out` to see if you navigate back to shopping list view.
3. check for sweet alerts responsiveness!
