### PR TITLE
Resolves 24. Changing to our own Firestore database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 # misc
 .vscode
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ Meat Cheese Bread is a React/Firestore web application that tcl-16 collaborated 
 
 <img width="1326" alt="Multi device mockup of Meat Cheese Bread" src="https://user-images.githubusercontent.com/62153993/111797842-e2222c00-889f-11eb-87f2-a47469b76c57.png">
 
-#### How does it work?
+### How does it work?
 As a user, you will enter items (e.g., “Greek yogurt” or “Paper towels”) into your list. Each time you buy the item, you mark it as purchased in the list. Over time, the app comes to understand the intervals at which you buy different items. If an item is likely to be due to be bought soon, it rises to the top of the shopping list.
 
-#### Want to see more?
-Interact with the [live site](https://meatcheesebread.xyz) and/or watch the [video demo](https://youtu.be/nDnrDOTV8zw)! You can join an existing list with: `mark marks swipe`
+### Want to see more?
+Interact with the [live site](https://meatcheesebread.xyz) and/or watch the [video demo](https://youtu.be/nDnrDOTV8zw)! You can join an existing list with: `actor racy artie`
 
 ## Getting Started
 ### Download Node and NPM

--- a/src/components/ShoppingList/PopulatedList/PopulatedList.scss
+++ b/src/components/ShoppingList/PopulatedList/PopulatedList.scss
@@ -51,16 +51,16 @@
 }
 
 .checkedItemContainer {
-  margin-right: 2rem;
+  margin-right: 0.5rem;
 }
 
 .itemDetailsContainer {
-  margin-left: 1em;
+  margin-left: 0.5em;
   min-width: 10em;
 }
 
 .countdownContainer {
-  min-width: 3em;
+  min-width: 2em;
   margin-left: 1em;
 }
 

--- a/src/lib/firebase.js
+++ b/src/lib/firebase.js
@@ -5,13 +5,13 @@ import "firebase/firestore";
 
 // Initalize Firebase.
 var firebaseConfig = {
-  apiKey: process.env.REACT_APP_apiKey,
-  authDomain: process.env.REACT_APP_authDomain,
-  projectId: process.env.REACT_APP_projectId,
-  storageBucket: process.env.REACT_APP_storageBucket,
-  messagingSenderId: process.env.REACT_APP_messagingSenderId,
-  appId: process.env.REACT_APP_appId,
-  measurementId: process.env.REACT_APP_measurementId,
+  apiKey: process.env.REACT_APP_API_KEY,
+  authDomain: process.env.REACT_APP_AUTH_DOMAIN,
+  projectId: process.env.REACT_APP_PROJECT_ID,
+  storageBucket: process.env.REACT_APP_STORAGE_BUCKET,
+  messagingSenderId: process.env.REACT_APP_MESSAGING_SENDER_ID,
+  appId: process.env.REACT_APP_APP_ID,
+  measurementId: process.env.REACT_APP_MEASUREMENT_ID,
 };
 
 let fb = firebase.initializeApp(firebaseConfig);

--- a/src/lib/firebase.js
+++ b/src/lib/firebase.js
@@ -1,16 +1,17 @@
 // NOTE: import only the Firebase modules that you need in your app... except
 // for the second line, which makes both the linter and react-firebase happy
-import firebase from 'firebase/app';
-import 'firebase/firestore';
+import firebase from "firebase/app";
+import "firebase/firestore";
 
 // Initalize Firebase.
 var firebaseConfig = {
-  apiKey: 'AIzaSyAryrdGGzIRpgNIBOYTYm1nbAGP1n60m3E',
-  authDomain: 'tcl-16-shopping-list.firebaseapp.com',
-  projectId: 'tcl-16-shopping-list',
-  storageBucket: 'tcl-16-shopping-list.appspot.com',
-  messagingSenderId: '673795137687',
-  appId: '1:673795137687:web:0cca36b195ad94bd0c89d2',
+  apiKey: process.env.REACT_APP_apiKey,
+  authDomain: process.env.REACT_APP_authDomain,
+  projectId: process.env.REACT_APP_projectId,
+  storageBucket: process.env.REACT_APP_storageBucket,
+  messagingSenderId: process.env.REACT_APP_messagingSenderId,
+  appId: process.env.REACT_APP_appId,
+  measurementId: process.env.REACT_APP_measurementId,
 };
 
 let fb = firebase.initializeApp(firebaseConfig);


### PR DESCRIPTION
## Description

In order to account for future features and work, we have switched to our own instance of Google's Cloud Firestore. This code updates our database to our own instance. In addition, we have hidden our API keys and updated the README accordingly.

Resources for hiding API keys:
- Sylwia Vargas's [article](https://betterprogramming.pub/how-to-hide-your-api-keys-c2b952bc07e6)
- Desmond Nyamador's [article](https://www.pluralsight.com/guides/hiding-secret-keys-in-create-react-app)

## Related Issue

closes #53 

## Acceptance Criteria

- Create our own Firestore database
- Share access to our own database with the rest of the team
- Update to the new database in our code
- Check that the behavior (read/write) remains the same

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|    | :bug: Bug fix              |
|    | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|  ✓  | :link: Update dependencies |
|  ✓  | :scroll: Docs              |

## Testing Steps / QA Criteria

Everyone on the team should have access to the new database, otherwise contact @wlcreate for more info! Once you have the updated information you should be able to read/write as usual.

